### PR TITLE
전체 레이아웃 디자인 시스템을 적용한다.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,16 +49,16 @@
       2,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
     ], 
-    "import/extensions": [
-      "error", 
-      "always", 
-      {
-        "ts": "always",
-        "tsx": "always",
-        "js": "always",
-        "jsx": "always"
-      }
-    ], 
+    // "import/extensions": [
+    //   "error", 
+    //   "always", 
+    //   {
+    //     "ts": "always",
+    //     "tsx": "always",
+    //     "js": "always",
+    //     "jsx": "always"
+    //   }
+    // ], 
     "no-use-before-define": 0, 
     "@typescript-eslint/naming-convention": [
       "error",
@@ -100,29 +100,31 @@
     
   },
   //로컬 파일에는 확장자를 강제하고, 패키지 모듈에서는 확장자를 생략
-  "overrides": [
-    {
-      "files": ["*.ts", "*.tsx"], // TypeScript 파일에만 적용
-      "rules": {
-        "import/extensions": [
-          "error",
-          "ignorePackages", // 패키지 모듈에 확장자 검사 생략
-          {
-            "ts": "always",
-            "tsx": "always",
-            "js": "always",
-            "jsx": "always"
-          }
-        ]
-      }
-    }
-  ],
+  // "overrides": [
+  //   {
+  //     "files": ["*.ts", "*.tsx"], // TypeScript 파일에만 적용
+  //     "rules": {
+  //       "import/extensions": [
+  //         "error",
+  //         "ignorePackages", // 패키지 모듈에 확장자 검사 생략
+  //         {
+  //           "ts": "always",
+  //           "tsx": "always",
+  //           "js": "always",
+  //           "jsx": "always"
+  //         }
+  //       ]
+  //     }
+  //   }
+  // ],
   "settings": {
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx", ".js"]
     },
     "import/resolver": {
-      "typescript": {}
+      "typescript": {
+        "project": "./tsconfig.json"
+      }
     }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -49,12 +49,16 @@
       2,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
     ], 
-    "import/extensions": ["error", "always", {
-      "ts": "always",
-      "tsx": "always",
-      "js": "always",
-      "jsx": "always"
-    }], 
+    "import/extensions": [
+      "error", 
+      "always", 
+      {
+        "ts": "always",
+        "tsx": "always",
+        "js": "always",
+        "jsx": "always"
+      }
+    ], 
     "no-use-before-define": 0, 
     "@typescript-eslint/naming-convention": [
       "error",
@@ -95,6 +99,24 @@
     "prefer-arrow/prefer-arrow-functions": "error" 
     
   },
+  //로컬 파일에는 확장자를 강제하고, 패키지 모듈에서는 확장자를 생략
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"], // TypeScript 파일에만 적용
+      "rules": {
+        "import/extensions": [
+          "error",
+          "ignorePackages", // 패키지 모듈에 확장자 검사 생략
+          {
+            "ts": "always",
+            "tsx": "always",
+            "js": "always",
+            "jsx": "always"
+          }
+        ]
+      }
+    }
+  ],
   "settings": {
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx", ".js"]

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/react-dom": "^19.0.2",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^2.2.0",
     "vite": "^3.2.0"
   },

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,39 +1,14 @@
-import { useRecoilState } from 'recoil';
-import { countState } from './Model/Atoms/atoms.ts';
-import { useState } from 'react';
-import './App.scss';
-import assets from './assets/assets.ts';
-// import Button from '../../shared/components/Button';
-import Button from '@shared/components/Button.tsx';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import TestPage from './View/TestPage.tsx';
+// import './App.scss';
 
 const App = () => {
-  // Recoil 상태로 관리
-  const [isCount, setCount] = useRecoilState(countState);
-
   return (
-    <div className='App'>
-      <div>
-        <a href='https://vitejs.dev' target='_blank'>
-          <img src={assets.viteLogo} className='logo' alt='Vite logo' />
-        </a>
-        <a href='https://reactjs.org' target='_blank'>
-          <img src='/react.svg' className='logo react' alt='React logo' />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className='card'>
-        <button onClick={() => setCount((prevCount) => prevCount + 1)}>
-          count is {isCount}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className='read-the-docs'>
-        Click on the Vite and React logos to learn more
-      </p>
-      <Button label='Press Me' onPress={() => alert('Pressed!')} />
-    </div>
+    <Router>
+      <Routes>
+        <Route path='/' element={<TestPage />} />
+      </Routes>
+    </Router>
   );
 };
 

--- a/front/src/AppTest.tsx
+++ b/front/src/AppTest.tsx
@@ -1,0 +1,40 @@
+import { useRecoilState } from 'recoil';
+import { countState } from './Model/Atoms/atoms.ts';
+import { useState } from 'react';
+import './App.scss';
+import assets from './assets/assets.ts';
+// import Button from '../../shared/components/Button';
+import Button from '@shared/components/Button.tsx';
+
+const App = () => {
+  // Recoil 상태로 관리
+  const [isCount, setCount] = useRecoilState(countState);
+
+  return (
+    <div className='App'>
+      <div>
+        <a href='https://vitejs.dev' target='_blank'>
+          <img src={assets.viteLogo} className='logo' alt='Vite logo' />
+        </a>
+        <a href='https://reactjs.org' target='_blank'>
+          <img src='/react.svg' className='logo react' alt='React logo' />
+        </a>
+      </div>
+      <h1>Vite + React</h1>
+      <div className='card'>
+        <button onClick={() => setCount((prevCount) => prevCount + 1)}>
+          count is {isCount}
+        </button>
+        <p>
+          Edit <code>src/App.tsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className='read-the-docs'>
+        Click on the Vite and React logos to learn more
+      </p>
+      <Button label='Press Me' onPress={() => alert('Pressed!')} />
+    </div>
+  );
+};
+
+export default App;

--- a/front/src/Index.tsx
+++ b/front/src/Index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import App from './App.tsx';
 import { RecoilRoot } from 'recoil';
 import './index.scss';
 

--- a/front/src/View/Test.Component.tsx
+++ b/front/src/View/Test.Component.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-type Props = {
+type testProps = {
   title: string;
 };
 
@@ -8,7 +8,7 @@ const test = () => {
   console.log('test');
 };
 
-const TestComponent: React.FC<Props> = ({ title }) => {
+const TestComponent: React.FC<testProps> = ({ title }) => {
   const [count, setCount] = useState<number>(0);
 
   return (

--- a/front/src/View/Test.error.tsx
+++ b/front/src/View/Test.error.tsx
@@ -6,6 +6,7 @@ import { missingModule } from './non-existent-file'; // 존재하지 않는 파�
 
 interface projectTest {}
 let test;
+
 function Test() {
   // prefer-arrow/prefer-arrow-functions : 화살표기 함수 누락으로 발생하는 error
   return (

--- a/front/src/View/TestPage.module.scss
+++ b/front/src/View/TestPage.module.scss
@@ -2,6 +2,7 @@
 .debug {
   width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   justify-content: center;
@@ -12,11 +13,30 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 100px;
+  background-color: wheat;
+
+  .debugDiv{
+    width: 100px;
+    display: flex;
+    padding: 10px;
+    color: white;
+    background-color: tomato;
+  }
+}
+
+.debugContentsEl{
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin: 50px auto;
+  background-color: yellowgreen;
   
   .debugDiv{
     width: 100px;
     display: flex;
     padding: 10px;
+    // height: 60px;
     color: white;
     background-color: tomato;
   }

--- a/front/src/View/TestPage.module.scss
+++ b/front/src/View/TestPage.module.scss
@@ -1,11 +1,23 @@
-.background{
-  background-color: #909090;
-  height: 100dvh;
-}
-
 /* 디버깅용 스타일 */
 .debug {
-  border: 2px dashed red; /* max-width 한계점 */
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  justify-content: center;
   background-color: #909090;
-  height: 100dvh;
+  // height: 100dvh;
+}
+.debugContents{
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  
+  .debugDiv{
+    width: 100px;
+    display: flex;
+    padding: 10px;
+    color: white;
+    background-color: tomato;
+  }
 }

--- a/front/src/View/TestPage.module.scss
+++ b/front/src/View/TestPage.module.scss
@@ -2,3 +2,10 @@
   background-color: #909090;
   height: 100dvh;
 }
+
+/* 디버깅용 스타일 */
+.debug {
+  border: 2px dashed red; /* max-width 한계점 */
+  background-color: #909090;
+  height: 100dvh;
+}

--- a/front/src/View/TestPage.module.scss
+++ b/front/src/View/TestPage.module.scss
@@ -1,0 +1,4 @@
+.background{
+  background-color: #909090;
+  height: 100dvh;
+}

--- a/front/src/View/TestPage.tsx
+++ b/front/src/View/TestPage.tsx
@@ -1,0 +1,11 @@
+import styles from './TestPage.module.scss';
+
+const TestPage = () => {
+  return (
+    <div className={styles.background}>
+      <span>test</span>
+    </div>
+  );
+};
+
+export default TestPage;

--- a/front/src/View/TestPage.tsx
+++ b/front/src/View/TestPage.tsx
@@ -1,4 +1,5 @@
 import styles from './TestPage.module.scss';
+import Button from '@shared/components/Button.tsx';
 
 const TestPage = () => {
   return (
@@ -27,6 +28,7 @@ const TestPage = () => {
         <div className={styles.debugDiv}>test</div>
         <div className={styles.debugDiv}>test</div>
       </div>
+      <Button label='Press Me' onPress={() => alert('Pressed!')} />
     </div>
   );
 };

--- a/front/src/View/TestPage.tsx
+++ b/front/src/View/TestPage.tsx
@@ -7,6 +7,26 @@ const TestPage = () => {
         <div className={styles.debugDiv}>test</div>
         <div className={styles.debugDiv}>test</div>
       </div>
+      <div className={styles.debugContentsEl}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
+      <div className={styles.debugContentsEl}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
+      <div className={styles.debugContentsEl}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
+      <div className={styles.debugContentsEl}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
+      <div className={styles.debugContentsEl}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
     </div>
   );
 };

--- a/front/src/View/TestPage.tsx
+++ b/front/src/View/TestPage.tsx
@@ -2,15 +2,11 @@ import styles from './TestPage.module.scss';
 
 const TestPage = () => {
   return (
-    <div
-      className={styles.debug}
-      style={{
-        width: '100%',
-        // maxWidth: '800px',
-        // minWidth: '400px',
-      }}
-    >
-      <span>test</span>
+    <div className={styles.debug}>
+      <div className={styles.debugContents}>
+        <div className={styles.debugDiv}>test</div>
+        <div className={styles.debugDiv}>test</div>
+      </div>
     </div>
   );
 };

--- a/front/src/View/TestPage.tsx
+++ b/front/src/View/TestPage.tsx
@@ -2,7 +2,14 @@ import styles from './TestPage.module.scss';
 
 const TestPage = () => {
   return (
-    <div className={styles.background}>
+    <div
+      className={styles.debug}
+      style={{
+        width: '100%',
+        // maxWidth: '800px',
+        // minWidth: '400px',
+      }}
+    >
       <span>test</span>
     </div>
   );

--- a/front/src/index.scss
+++ b/front/src/index.scss
@@ -1,70 +1,29 @@
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
+// 기본 리셋
+* {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+// 전체 레이아웃 기본 스타일
+body {
+  font-family: 'Arial', sans-serif;
+  line-height: 1.5;
+  // color: #333;
+  background-color: #f9f9f9;
+  width: 100%;
+  // max-width: 1200px;
+  // min-width: 650px;
+  max-width: 745px;
+  margin: 0 auto;
+  padding: 0 16px;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+// 반응형 유틸리티
+// .container {
+//   width: 100%;
+//   max-width: 1200px;
+//   margin: 0 auto;
+//   padding: 0 16px;
+// }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/front/src/index.scss
+++ b/front/src/index.scss
@@ -16,15 +16,17 @@ body {
   // min-width: 650px;
   max-width: 430px;
   min-width: 366px;
+  // height: 100vh;
   margin: 0 auto;
   padding: 0 32px; //padding을 통해서 여백을 만들어낼 수 있다.
 }
 
-// 반응형 유틸리티
-// .container {
-//   width: 100%;
-//   max-width: 1200px;
-//   margin: 0 auto;
-//   padding: 0 16px;
+// 웹에서 최소 일때 꽉찬 화면으로 수정
+// @media (max-width: 500px) {
+//   body {
+//     padding: 0; /* 특정 구간에서 padding 제거 */
+//     max-width: 500px;
+//   }
 // }
+
 

--- a/front/src/index.scss
+++ b/front/src/index.scss
@@ -14,9 +14,10 @@ body {
   width: 100%;
   // max-width: 1200px;
   // min-width: 650px;
-  max-width: 745px;
+  max-width: 430px;
+  min-width: 366px;
   margin: 0 auto;
-  padding: 0 16px;
+  padding: 0 32px; //padding을 통해서 여백을 만들어낼 수 있다.
 }
 
 // 반응형 유틸리티

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.2
         version: 19.0.2(@types/react@18.3.16)
+      '@types/react-router-dom':
+        specifier: ^5.3.3
+        version: 5.3.3
       '@vitejs/plugin-react':
         specifier: ^2.2.0
         version: 2.2.0(vite@3.2.11(@types/node@22.10.2)(sass@1.82.0)(terser@5.37.0))
@@ -1226,6 +1229,9 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
+  '@types/history@4.7.11':
+    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -1258,6 +1264,12 @@ packages:
   '@types/react-native@0.73.0':
     resolution: {integrity: sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==}
     deprecated: This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.
+
+  '@types/react-router-dom@5.3.3':
+    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
+
+  '@types/react-router@5.1.20':
+    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react@18.3.16':
     resolution: {integrity: sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==}
@@ -6188,6 +6200,8 @@ snapshots:
     dependencies:
       '@types/node': 22.10.2
 
+  '@types/history@4.7.11': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -6229,6 +6243,17 @@ snapshots:
       - react
       - supports-color
       - utf-8-validate
+
+  '@types/react-router-dom@5.3.3':
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 18.3.16
+      '@types/react-router': 5.1.20
+
+  '@types/react-router@5.1.20':
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 18.3.16
 
   '@types/react@18.3.16':
     dependencies:


### PR DESCRIPTION
## #️⃣ Issue Number
- close #67 

## ✏️Task
- [x] index.scss에 전체 레이아웃 디자인 시스템을 적용한다.
  - [x] index.scss의 중앙 정렬 선택을 flex로 할지 margin auto로 작업을 할지 고민한다.
  - [x] max와 min의 차이를 명확히 구분한다.

## 🔗Reference
> 참고 링크
  - 없다면 지워주세요.
   🔗 [참고 링크](https://# "참고 링크")

## ✏️Tasks Description
- ## index.scss의 중앙 정렬을 margin auto로 작업한다.
  - 왜 margin atuo냐면 글로벌 css를 flex로 사용하면 css가 더 복잡해질 수 있다. `margin: 0 auto;`는 독립적인 스타일로 동작하며, 부모 컨테이너의 레이아웃 방식에 의존하지 않는다. 또한 flex는 부모, 자식의 display 속성에 따라 영향(**flex-grow, flex-shrink 등과의 충돌**)을 받으므로 컨텍스트(CSS 속성의 영향을 받는 환경)에 따라 코드가 의도치 않게 변경될 가능성이 있다. 더해서 `margin: 0 auto;`는 브라우저 렌더링 엔진에 의해 예상 가능한 방식으로 적용되므로 SEO의 안정성을 추구할 수 있다. 조금 더 구체적으로 말하자면 `margin: 0 auto`는 자식 요소의 배치를 브라우저 렌더링 엔진이 예측 가능하게 처리한다. 따라서 간단한 **중앙 정렬은 `margin: 0 auto`를 사용하는 것이 좋다.**

- ## 글로벌 flex or margin auto 자식 요소 margin auto or flex의 충돌 가능성
  - 글로벌 flex  자식 요소 margin auto
    ```
        /* 글로벌 스타일 */
        body {
          display: flex;
          justify-content: center;
          align-items: center;
        }
        
        /* 자식 스타일 */
        .child {
          margin: 0 auto; /* 기대했던 중앙 정렬이 깨질 가능성 */
        }
    ```
  
  - 글로벌 margin auto 자식 요소 flex 
      ```
      /* 글로벌 스타일 */
      body {
        margin: 0 auto;
      }
      
      /* 자식 스타일 */
      .child {
        display: flex;
        justify-content: center;
        align-items: center;
      }
      ```
#

- ## max와 min의 차이를 명확히 구분한다.
  - max값은 지정된 값 보다 더 이상 커질 수 없는 것이다. min값은 지정된 값 보다 더 이상 작아 질 수 없는 것이다. 즉, 다시 설명하자면 max와 min 값이 글로벌로 정해져있기 때문에 자식 컴포넌트나 UI들의 width 값은 `100%`를 따라 값을 설정하고 이를 활용하면 되는 것이다. 이를 활용한다면 width의 값을 직접 자식 컴포넌트에서 공통된 특정 값을 반복해서 지정해줄 필요가 없는 것이다. 따라서, 이를 개발자 도구 CSS로 디버깅 할 수 있다.
  - ### 글로벌 css의 `padding: 0 16px`은 어떤 역할을 하는가?
    - 특정 여백을 지정할 수 있다. 이는 `box-sizing`과 깊은 연관이 있다.
  - ### `box-sizing`의 종류
    - content-box : 부모의 콘텐츠 영역 기준으로 계산. 즉, padding을 전역으로 설정해도 넓이(width)가 자동으로 padding값을  계산하지 않는다. 즉, `430px` 넓이와  `32px` 패딩이 각기 따로 동작을 한다.
    - border-box : 부모의 전체 영역 기준으로 계산. 즉, padding을 전역으로 설정하면 자동으로 padding값을 계산한다. 즉, `430px` 넓이와  `32px` 패딩이 적용된 넓이 `366px` 결과가 나온다.

#

# Eslint 규칙 수정
- `import/extensions`와 `overrides/import/resolver` 설정이 `tsconfig.json/moduleResolution`과 충돌로 인해 제거
- ⚠ `prefer-arrow/prefer-arrow-functions`의 플러그인이 VSC에 적용되는데 까지 시간이 다소 걸린다.
### 🗓Next Task
- 
