### PR TITLE
`useGlobalApiState.tsx` 를 점검한다.

### DIFF
--- a/front/src/Controller/StudyFactoryApi.tsx
+++ b/front/src/Controller/StudyFactoryApi.tsx
@@ -28,7 +28,7 @@ interface ApiResponse {
 }
 
 const StudyFactoryApi = ({ uri, page }: { uri: string; page: number }) => {
-  const [targetId, setTargetId] = useState<number | null>(null);
+  const [targetId] = useState<number | null>(null);
   const { isLoading, isError, data, isSuccess, refetch } =
     useApiQuery<ApiResponse>(
       `https://13.209.113.229.nip.io/api/wordbook?id=${uri}&page=${page}`,
@@ -41,9 +41,9 @@ const StudyFactoryApi = ({ uri, page }: { uri: string; page: number }) => {
     method: 'DELETE',
   });
 
-  const handleDelete = (id: number) => {
-    setTargetId(id);
-  };
+  // const handleDelete = (id: number) => {
+  //   setTargetId(id);
+  // };
 
   useEffect(() => {
     refetch();
@@ -86,7 +86,7 @@ const StudyFactoryApi = ({ uri, page }: { uri: string; page: number }) => {
               screwShape={el.explanation}
               highlight={el.highlight}
               check={el.check}
-              onDeleteTrigger={(id) => handleDelete(id)}
+              // onDeleteTrigger={(id) => handleDelete(id)}
               isSuccessState={deletedSuccess}
             />
           </div>

--- a/front/src/Model/Hook/useGlobalApiState.ts
+++ b/front/src/Model/Hook/useGlobalApiState.ts
@@ -20,7 +20,7 @@ const useGlobalApiState = ({
   // const mode = useSelector((state: RootState) => state.setFactoryMode.mode);
   const toolMode = useSelector((state: RootState) => state.setToolMode.tool);
   //리팩토링 필요
-  const active = useCallback(
+  const modeActive = useCallback(
     (mode?: 'deleted' | 'edit' | 'shared' | 'duplicated' | 'highlight') => {
       // foactory mode
       if (!mode && !toggle) return;
@@ -54,8 +54,13 @@ const useGlobalApiState = ({
       }
       // tool mode
       // usecallback으로 active 생성
-      if (!toolMode || toolMode.length === 0) return;
-      switch (toolMode[0]) {
+    },
+    [toggle, id],
+  );
+  const toolModeActive = useCallback(
+    (toolMode?: 'highlight' | 'deleted') => {
+      if (!toolMode) return;
+      switch (toolMode) {
         case 'highlight':
           // console.log(`${toolMode}: ${id}`);
           if (id !== undefined) {
@@ -65,7 +70,7 @@ const useGlobalApiState = ({
               },
               {
                 onSuccess: () => {
-                  console.log(`✅ Screw ${id} 삭제 성공`);
+                  console.log(`✅ Screw ${id} highlight 성공`);
                 },
               },
             );
@@ -94,9 +99,8 @@ const useGlobalApiState = ({
           break;
       }
     },
-    [toggle, toolMode, id],
+    [toggle, id],
   );
-
   useEffect(() => {
     if (isSuccess) {
       console.log('🟢 삭제 성공:', isSuccess);
@@ -106,7 +110,7 @@ const useGlobalApiState = ({
     }
   }, [isSuccess]);
 
-  return { isSuccess, isLoading, active };
+  return { isSuccess, isLoading, modeActive, toolModeActive };
 };
 
 export default useGlobalApiState;

--- a/front/src/Model/Hook/useGlobalApiState.ts
+++ b/front/src/Model/Hook/useGlobalApiState.ts
@@ -53,6 +53,7 @@ const useGlobalApiState = ({
         console.log('Not Mode');
       }
       // tool mode
+      // usecallback으로 active 생성
       if (!toolMode || toolMode.length === 0) return;
       switch (toolMode[0]) {
         case 'highlight':

--- a/shared/components/Alarm.tsx
+++ b/shared/components/Alarm.tsx
@@ -32,7 +32,7 @@ const Alarm = ({
 
   const mode = useSelector((state: RootState) => state.setFactoryMode.mode);
 
-  const { isLoading, isSuccess, active } = useGlobalApiState({
+  const { isLoading, isSuccess, modeActive } = useGlobalApiState({
     id: id,
     method: 'DELETE',
   });
@@ -67,7 +67,7 @@ const Alarm = ({
             id={styles.buttonApprove}
             onClick={() => {
               //여기에 매개변수로 전달
-              if (method) active('deleted');
+              if (method) modeActive('deleted');
             }}
           >
             예

--- a/shared/components/BuildFactory.tsx
+++ b/shared/components/BuildFactory.tsx
@@ -49,6 +49,7 @@ const BuildFactory = ({
     const { mutation, isLoading, isError, isSuccess, responseData } =
       useApiMutation(sesscctionMode !== 'edit' ? 'POST' : 'PUT');
 
+    //다른 전역 상태 API 관리 방식과는 전혀 다른 특이 케이스 어떻게 관리하면 좋을지 고민이 필요하다.
     const onSubmit = (data: FormData) => {
       console.log('생성된 Factory:', data.bookName);
       mutation.mutate(

--- a/shared/components/inner/Screw.tsx
+++ b/shared/components/inner/Screw.tsx
@@ -14,7 +14,7 @@ const Screw = ({
   screwShape,
   highlight,
   check,
-  onDeleteTrigger,
+  // onDeleteTrigger,
   isSuccessState,
 }: {
   id: number;
@@ -25,30 +25,25 @@ const Screw = ({
   screwShape: string;
   highlight: boolean;
   check: boolean;
-  onDeleteTrigger?: (deleteId: number) => void;
+  // onDeleteTrigger?: (deleteId: number) => void;
   isSuccessState?: boolean;
 }) => {
   const { mutation, isSuccess, isLoading, isError, responseData } =
     useApiMutation('POST');
+
   const mode = useSelector((state: RootState) => state.setToolMode.tool);
+  const [isMethod, setMethod] = useState<'POST' | 'PUT' | 'DELETE'>('POST');
   const [isHidden, setHidden] = useState<boolean>(
     typeof isSuccessState === 'boolean' ? isSuccessState : false,
   );
-
-  const { mutation: highlightMutation } = useApiMutation('POST');
-  // const { active: highlightActive } = useGlobalApiState({
-  //   id,
-  //   method: 'POST',
-  // });
-  const { active: deleteActive } = useGlobalApiState({
-    id,
-    method: 'DELETE',
-  });
-
   const [isChecked, setChecked] = useState<boolean>(check);
   const [isSelected, setSelected] = useState<boolean>(false);
-  // bolt와 각 nut의 highlight 상태 관리
   const [isHighlighted, setHighlighted] = useState<boolean>(highlight);
+
+  const { isSuccess: toolSuccess, toolModeActive } = useGlobalApiState({
+    id,
+    method: isMethod,
+  });
 
   useEffect(() => {
     if (isSuccess) {
@@ -60,7 +55,10 @@ const Screw = ({
     if (isError) {
       console.log('isError');
     }
-  }, [isSuccess, isLoading, isError, mode]);
+    if (toolSuccess) {
+      setHidden(!isHidden);
+    }
+  }, [isSuccess, isLoading, isError, toolSuccess, mode]);
 
   if (Platform.OS === 'web') {
     const onCheckboxChange = () => {
@@ -68,31 +66,20 @@ const Screw = ({
     };
 
     const onScrewSelected = () => {
+      setMethod('DELETE');
       if (mode.includes('deleted')) {
-        deleteActive('deleted');
+        toolModeActive('deleted');
         setSelected(!isSelected);
-        if (onDeleteTrigger) {
-          console.log('click');
-          onDeleteTrigger(id);
-          setHidden(!isHidden);
-        }
-        console.log(id);
       }
     };
 
     const onHighlight = () => {
-      setHighlighted(!isHighlighted);
-      highlightMutation.mutate(
-        {
-          mutateUrl: `https://13.209.113.229.nip.io/api/word/highlight/${id}`,
-        },
-        {
-          onSuccess: () => {
-            console.log(`✅ Screw ${id} 하이라이트 성공`);
-          },
-        },
-      );
-      // highlightActive('highlight');
+      setMethod('POST');
+      if (mode.includes('highlight')) {
+        console.log(typeof id);
+        toolModeActive('highlight');
+        setHighlighted(!isHighlighted);
+      }
     };
 
     // const temp = true;
@@ -122,8 +109,10 @@ const Screw = ({
         className={isSelected ? styles.checked : styles.unchecked}
         onClick={() => {
           if (mode.includes('deleted')) {
+            console.log('deleted');
             onScrewSelected();
           } else if (mode.includes('highlight')) {
+            console.log('highlight');
             onHighlight();
           }
         }}


### PR DESCRIPTION
## #️⃣ Issue Number
- close # Issue Number

## ✏️Task
- [x] toolMode와 mode 관리를 분리해서 할 수 있게 코드를 변경한다.
- [x] toolMode를 useCallback을 사용해서 active 함수를 커스텀훅에 추가한다.

## 🔗Reference
> 참고 링크
  - 없다면 지워주세요.
   🔗 [참고 링크](https://# "참고 링크")

## ✏️Tasks Description
- [✨: useGlobalApiState의 문제를 해결](https://github.com/p-factory/P-factory-Front/commit/8139f6b7503e158da0e56b1f042976ef02eddfe4)
- 현재 `edit` 모드인 경우의 api가 `useGlobalApiState`에서 관리되고 있지 않는다. 해당 api는 `BuildFactory` 내부에서 삼항연산으로 계산되어서 동작을 하고 있다. 따라서 `useGlobalApiState`에서 어떻게 관리가 되면 좋을지 고민해볼 필요가 있다. (이외 check, favoirite와 같은 API를 어떻게 관리해야 좋을지 함께 고민해야 한다.)

### 🗓Next Task
- 
